### PR TITLE
fix: sa_mask leak

### DIFF
--- a/sources/server.c
+++ b/sources/server.c
@@ -37,7 +37,8 @@ static void	recive_message(int sig, siginfo_t *siginfo, void *context)
 int	main(void)
 {
 	struct sigaction	act;
-
+	
+	sigemptyset(&act.sa_mask);
 	act.sa_flags = SA_SIGINFO;
 	act.sa_sigaction = recive_message;
 	sigaction(SIGUSR1, &act, NULL);


### PR DESCRIPTION
When you run ./server with valgrind it shows a leak:

```c
==23892== Syscall param rt_sigaction(act->sa_mask) points to uninitialised byte(s)
==23892==    at 0x48AE196: __libc_sigaction (sigaction.c:58)
==23892==    by 0x4011E9: main (in /..../server)
==23892==  Address 0x1ffefff638 is on thread 1's stack
==23892==  in frame #0, created by __libc_sigaction (sigaction.c:43)
```
We can solve it declaring act = {0} on the same line, but norminette not allows it. So we need to use sigemptyset to initialize a empty value for mask.

Stackoverflow comment: https://stackoverflow.com/questions/43155640/signal-handling-for-background-processes#comment73604291_43155838

:rocket: